### PR TITLE
Add private repo support for gitlab

### DIFF
--- a/cogs/print_snippets.py
+++ b/cogs/print_snippets.py
@@ -112,11 +112,15 @@ class PrintSnippets(Cog):
             elif gl_match:
                 d = gl_match.groupdict()
                 await self.orig_to_encode(d)
+                headers = {}
+                if 'GITLAB_TOKEN' in os.environ:
+                    headers['PRIVATE-TOKEN'] = os.environ["GITLAB_TOKEN"]
                 async with aiohttp.ClientSession() as session:
                     file_contents = await self.fetch(
                         session,
                         f'https://gitlab.com/api/v4/projects/{d["repo"]}/repository/files/{d["file_path"]}/raw?ref={d["branch"]}',
                         'text',
+                        headers=headers,
                     )
                 await self.revert_to_orig(d)
             elif bb_match:


### PR DESCRIPTION
The `GITLAB_TOKEN` env var can be set to a personal access tokens to add support private repos