### PR TITLE
Use a single aiohttp session

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -5,8 +5,11 @@ A Discord bot that removes embeds and prints out specific lines of code
 when a GitHub or GitLab link is sent
 """
 
+import asyncio
 import os
 import logging
+
+import aiohttp
 
 from discord import Activity, ActivityType
 from discord.ext.commands import Bot, when_mentioned_or
@@ -15,22 +18,28 @@ from cogs.bot_info import BotInfo
 from cogs.print_snippets import PrintSnippets
 from cogs.top_gg import TopGG
 
-logging.basicConfig(level=logging.INFO)
 
-prefix = 'g;'
-if 'BOT_PREFIX' in os.environ:
-    prefix = os.environ['BOT_PREFIX']
+async def main():
+    logging.basicConfig(level=logging.INFO)
 
-bot = Bot(
-    command_prefix=when_mentioned_or(prefix),
-    help_command=None,
-    activity=Activity(type=ActivityType.watching, name=f'for snippet links and {prefix}help'),
-)
+    prefix = os.environ.get('BOT_PREFIX', 'g;')
 
-bot.add_cog(BotInfo(bot))
-bot.add_cog(PrintSnippets(bot))
+    bot = Bot(
+        command_prefix=when_mentioned_or(prefix),
+        help_command=None,
+        activity=Activity(type=ActivityType.watching, name=f'for snippet links and {prefix}help'),
+    )
 
-if 'TOP_GG_TOKEN' in os.environ:
-    bot.add_cog(TopGG(bot))
+    async with aiohttp.ClientSession() as session:
+        bot.add_cog(BotInfo(bot))
+        bot.add_cog(PrintSnippets(bot, session))
 
-bot.run(os.environ['DISCORD_TOKEN'])
+        if 'TOP_GG_TOKEN' in os.environ:
+            bot.add_cog(TopGG(bot))
+
+        await bot.start(os.environ['DISCORD_TOKEN'])
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())

--- a/bot.py
+++ b/bot.py
@@ -42,4 +42,8 @@ async def main():
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+
+    try:
+        loop.run_until_complete(main())
+    except KeyboardInterrupt:
+        loop.close()

--- a/tests/test_print_snippets.py
+++ b/tests/test_print_snippets.py
@@ -1,8 +1,9 @@
-from discord.ext.commands import Bot
+import aiohttp
 import discord.ext.test as dpytest
 import pytest
 
 from cogs.print_snippets import PrintSnippets
+from discord.ext.commands import Bot
 
 
 @pytest.mark.asyncio
@@ -11,7 +12,7 @@ async def test_github():
 
     bot = Bot(command_prefix='.')
 
-    bot.add_cog(PrintSnippets(bot))
+    bot.add_cog(PrintSnippets(bot, aiohttp.ClientSession()))
 
     dpytest.configure(bot)
 
@@ -38,7 +39,7 @@ async def test_github_gists():
 
     bot = Bot(command_prefix='.')
 
-    bot.add_cog(PrintSnippets(bot))
+    bot.add_cog(PrintSnippets(bot, aiohttp.ClientSession()))
 
     dpytest.configure(bot)
 
@@ -65,7 +66,7 @@ async def test_gitlab():
 
     bot = Bot(command_prefix='.')
 
-    bot.add_cog(PrintSnippets(bot))
+    bot.add_cog(PrintSnippets(bot, aiohttp.ClientSession()))
 
     dpytest.configure(bot)
 
@@ -95,7 +96,7 @@ async def test_bitbucket():
 
     bot = Bot(command_prefix='.')
 
-    bot.add_cog(PrintSnippets(bot))
+    bot.add_cog(PrintSnippets(bot, aiohttp.ClientSession()))
 
     dpytest.configure(bot)
 


### PR DESCRIPTION
From [aiohttp docs](https://docs.aiohttp.org/en/v3.0.1/client_quickstart.html#make-a-request):
> Don’t create a session per request. Most likely you need a session per application which performs all requests altogether.
>
> A session contains a connection pool inside. Connection reusage and keep-alives (both are on by default) may speed up total performance.