### PR TITLE
Do not suppress links on dms and groups

### DIFF
--- a/cogs/print_snippets.py
+++ b/cogs/print_snippets.py
@@ -73,12 +73,13 @@ class PrintSnippets(Cog):
 
             if 0 < len(message_to_send) <= 2000 and message_to_send.count('\n') <= 50:
                 sent_message = await message.channel.send(message_to_send)
-                await message.edit(suppress=True)
+                if message.guild is not None:
+                    await message.edit(suppress=True)
                 await sent_message.add_reaction('❌')
 
                 def check(reaction, user):
                     return user == message.author and str(reaction.emoji) == '❌'
-                
+
                 try:
                     reaction, user = await self.bot.wait_for('reaction_add', timeout=10.0, check=check)
                 except asyncio.TimeoutError:


### PR DESCRIPTION
Fixes the following error message which happens when sending from dm:
```
Ignoring exception in on_message
Traceback (most recent call last):
  File "/home/mukundan/.local/share/virtualenvs/git-the-lines-ERQ5-elH/lib/python3.8/site-packages/discord/client.py", line 312, in _run_event
    await coro(*args, **kwargs)
  File "/home/mukundan/Documents/git/github.com/mukundan314/git-the-lines/cogs/print_snippets.py", line 76, in on_message
    await message.edit(suppress=True)
  File "/home/mukundan/.local/share/virtualenvs/git-the-lines-ERQ5-elH/lib/python3.8/site-packages/discord/message.py", line 829, in edit
    data = await self._state.http.edit_message(self.channel.id, self.id, **fields)
  File "/home/mukundan/.local/share/virtualenvs/git-the-lines-ERQ5-elH/lib/python3.8/site-packages/discord/http.py", line 221, in request
    raise Forbidden(r, data)
discord.errors.Forbidden: 403 Forbidden (error code: 50003): Cannot execute action on a DM channel
```