### PR TITLE
Add support for links without line ranges

### DIFF
--- a/cogs/code_snippets.py
+++ b/cogs/code_snippets.py
@@ -14,24 +14,25 @@ from cogs.utils import (fetch_bitbucket_snippet, fetch_github_gist_snippet,
                         fetch_github_snippet, fetch_gitlab_snippet)
 
 GITHUB_RE = re.compile(
-    r'https://github\.com/(?P<repo>\S+?)/blob/(?P<path>\S+/\S+)'
-    r'#L(?P<start_line>\d+)([-~:]L(?P<end_line>\d+))?\b'
+    r'https://github\.com/(?P<repo>\S+?)/blob/(?P<path>\S+/[^\s#]+)'
+    r'(#L(?P<start_line>\d+)([-~:]L(?P<end_line>\d+))?)?($|\s)'
 )
 
 GITHUB_GIST_RE = re.compile(
     r'https://gist\.github\.com/([^/]+)/(?P<gist_id>[^\W_]+)/*'
     r'(?P<revision>[^\W_]*)/*#file-(?P<file_path>\S+?)'
-    r'-L(?P<start_line>\d+)([-~:]L(?P<end_line>\d+))?\b'
+    r'(-L(?P<start_line>\d+)([-~:]L(?P<end_line>\d+))?)?($|\s)'
 )
 
 GITLAB_RE = re.compile(
-    r'https://gitlab\.com/(?P<repo>\S+?)/\-/blob/(?P<path>\S+/\S+)'
-    r'#L(?P<start_line>\d+)([-](?P<end_line>\d+))?\b'
+    r'https://gitlab\.com/(?P<repo>\S+?)/\-/blob/(?P<path>\S+/[^\s#]+)'
+    r'(#L(?P<start_line>\d+)([-](?P<end_line>\d+))?)?($|\s)'
 )
 
 BITBUCKET_RE = re.compile(
-    r'https://bitbucket\.org/(?P<repo>\S+?)/src/(?P<ref>\S+?)/'
-    r'(?P<file_path>\S+?)#lines-(?P<start_line>\d+)(:(?P<end_line>\d+))?\b'
+    r'https://bitbucket\.org/(?P<repo>\S+?)/src/'
+    r'(?P<ref>\S+?)/(?P<file_path>[^\s#]+)'
+    r'(#lines-(?P<start_line>\d+)(:(?P<end_line>\d+))?)?($|\s)'
 )
 
 

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -116,13 +116,15 @@ async def fetch_bitbucket_snippet(session, repo, ref, file_path, start_line, end
 async def snippet_to_embed(file_contents, file_path, start_line, end_line):
     """Given file contents, file path, start line and end line creates a code block"""
 
-    if end_line is None:
+    split_file_contents = file_contents.splitlines()
+
+    if start_line is None:
+        start_line, end_line = 1, len(split_file_contents)
+    elif end_line is None:
         start_line = end_line = int(start_line)
     else:
         start_line = int(start_line)
         end_line = int(end_line)
-
-    split_file_contents = file_contents.splitlines()
 
     if start_line > end_line:
         start_line, end_line = end_line, start_line

--- a/tests/test_print_snippets.py
+++ b/tests/test_print_snippets.py
@@ -39,6 +39,10 @@ async def test_github(bot):
     await dpytest.message('https://github.com/dolphingarlic/git-the-lines/blob/master/bot.py#L0~L2')
     dpytest.verify_message('```py\n"""\nGit the lines```')
 
+    # Test no line range
+    await dpytest.message('https://github.com/dolphingarlic/git-the-lines/blob/master/Procfile')
+    dpytest.verify_message('```Procfile\nworker: python bot.py```')
+
 
 @pytest.mark.asyncio
 async def test_github_gists(bot):
@@ -87,6 +91,10 @@ async def test_gitlab(bot):
     # Test no file extension
     await dpytest.message('https://gitlab.com/dolphingarlic/bot-testing/-/blob/master/nested/fi.l/ee#L1')
     dpytest.verify_message('```ee\nMinu nimi on Andi```')
+
+    # Test no line range
+    await dpytest.message('https://gitlab.com/dolphingarlic/bot-testing/-/blob/master/nested/fi.l/e.py')
+    dpytest.verify_message('```py\nprint(\'Hi\')\nprint(1 + 3)```')
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add support for whole files i.e. when sent a link like https://bitbucket.org/avdg/ai-bot-cpp/src/master/Makefile the bot will respond with the whole file
![1598276670](https://user-images.githubusercontent.com/30190448/91051915-62e8b480-e63e-11ea-9f68-ae695e64c4b7.png)